### PR TITLE
Fix column name for users reference to author

### DIFF
--- a/db/migrate/20230201002509_create_post.rb
+++ b/db/migrate/20230201002509_create_post.rb
@@ -1,7 +1,7 @@
 class CreatePost < ActiveRecord::Migration[7.0]
   def change
     create_table :posts do |t|
-      t.references :author, foreign_key: { to_table: :users}
+      t.references :author, foreign_key: { to_table: :users }
       t.string :title
       t.text :text
       t.integer :comments_counter

--- a/db/migrate/20230201002620_create_comment.rb
+++ b/db/migrate/20230201002620_create_comment.rb
@@ -1,8 +1,8 @@
 class CreateComment < ActiveRecord::Migration[7.0]
   def change
     create_table :comments do |t|
-      t.references :author, foreign_key: { to_table: :users}
-      t.references :posts, null: false, foreign_key: {to_table: :posts}
+      t.references :author, foreign_key: { to_table: :users }
+      t.references :posts, null: false, foreign_key: { to_table: :posts }
       t.text :text
 
       t.timestamps

--- a/db/migrate/20230201002652_create_like.rb
+++ b/db/migrate/20230201002652_create_like.rb
@@ -1,8 +1,8 @@
 class CreateLike < ActiveRecord::Migration[7.0]
   def change
     create_table :likes do |t|
-      t.references :author, foreign_key: { to_table: :users}
-      t.references :posts, null: false, foreign_key: {to_table: :posts}
+      t.references :author, foreign_key: { to_table: :users }
+      t.references :posts, null: false, foreign_key: { to_table: :posts }
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,33 +15,33 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_01_002652) do
   enable_extension "plpgsql"
 
   create_table "comments", force: :cascade do |t|
-    t.bigint "users_id", null: false
+    t.bigint "author_id"
     t.bigint "posts_id", null: false
     t.text "text"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["author_id"], name: "index_comments_on_author_id"
     t.index ["posts_id"], name: "index_comments_on_posts_id"
-    t.index ["users_id"], name: "index_comments_on_users_id"
   end
 
   create_table "likes", force: :cascade do |t|
-    t.bigint "users_id", null: false
+    t.bigint "author_id"
     t.bigint "posts_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["author_id"], name: "index_likes_on_author_id"
     t.index ["posts_id"], name: "index_likes_on_posts_id"
-    t.index ["users_id"], name: "index_likes_on_users_id"
   end
 
   create_table "posts", force: :cascade do |t|
-    t.bigint "users_id", null: false
+    t.bigint "author_id"
     t.string "title"
     t.text "text"
     t.integer "comments_counter"
     t.integer "likes_counter"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["users_id"], name: "index_posts_on_users_id"
+    t.index ["author_id"], name: "index_posts_on_author_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -54,8 +54,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_01_002652) do
   end
 
   add_foreign_key "comments", "posts", column: "posts_id"
-  add_foreign_key "comments", "users", column: "users_id"
+  add_foreign_key "comments", "users", column: "author_id"
   add_foreign_key "likes", "posts", column: "posts_id"
-  add_foreign_key "likes", "users", column: "users_id"
-  add_foreign_key "posts", "users", column: "users_id"
+  add_foreign_key "likes", "users", column: "author_id"
+  add_foreign_key "posts", "users", column: "author_id"
 end


### PR DESCRIPTION
In this PR i played around with the migration until I figured out how to change the reference column's name in comments, posts, and likes (now it will be author_id).